### PR TITLE
Using shared logic for default versions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -290,4 +290,4 @@ texinfo_documents = [
 
 
 def setup(app):
-    app.add_stylesheet("sphinx-argparse.css")
+    app.add_css_file("sphinx-argparse.css")

--- a/docs/getting_started/developer-guide.rst
+++ b/docs/getting_started/developer-guide.rst
@@ -629,36 +629,6 @@ use is the following:
  - For each of latest and tags, add new version information
 
 
-.. _getting_started-development-version-files:
-
-Version Files
-=============
-
-The way that we define default versions for each of lmod and tcl is complicated enough that it is worth
-generating a table to show you! If you see a way to improve upon our current implementation, please let us know.
-Note that for the below, "automatic" refers to the setting ``default_version_automatic``, saying you want
-shpc to automatically update any default version files, and "default_version"
-refers to the ``default_version`` version setting, saying you want shpc to create and update a default version file.
-
-.. list-table:: Version File Logic
-   :widths: 20 20 20 20
-   :header-rows: 1
-
-   * - default_version
-     - false
-     - true but not automatic
-     - true and automatic
-   * - Lmod
-     - No .version file
-     - empty .version file, or .version file with a dummy non-matching string
-     - non-empty .version file, with a version number that exists
-   * - TCL
-     - .version file with a dummy non-matching string
-     - No .version file
-     - non-empty .version file, with a version number that exists
-
-In the case of a "dummy non-matching string" you could set something like ``please_specify_a_version_number``.
-
 .. _getting_started-development:
 
 Development or Testing

--- a/docs/getting_started/developer-guide.rst
+++ b/docs/getting_started/developer-guide.rst
@@ -629,7 +629,7 @@ use is the following:
  - For each of latest and tags, add new version information
 
 
-.. _getting_started-develpoment-version-files:
+.. _getting_started-development-version-files:
 
 Version Files
 =============

--- a/docs/getting_started/developer-guide.rst
+++ b/docs/getting_started/developer-guide.rst
@@ -257,7 +257,7 @@ For these global scripts, the user can select to use it in their settings.yaml.
 We will eventually write a command to list global wrappers available, so if you add a new one future users will know
 about it. For alias wrapper scripts, the following variables are passed for rendering:
 
-.. list-table:: Title
+.. list-table:: Wrapper Script Variables
    :widths: 15 15 40 30
    :header-rows: 1
 
@@ -306,7 +306,7 @@ If you want to write a custom container.yaml script:
 
 The following variables are passed for rendering.
 
-.. list-table:: Title
+.. list-table:: Container YAML Alias Variables
    :widths: 15 15 40 30
    :header-rows: 1
 
@@ -523,7 +523,7 @@ Registry Yaml Fields
 
 Fields include:
 
-.. list-table:: Title
+.. list-table:: Registry YAML Fields
    :widths: 25 65 10
    :header-rows: 1
 
@@ -571,7 +571,7 @@ A complete table of features is shown here. The
 
 Fields include:
 
-.. list-table:: Title
+.. list-table:: Features
    :widths: 20 20 20 10 10 10
    :header-rows: 1
 
@@ -628,6 +628,36 @@ use is the following:
  - If latest is defined and a version string can be parsed, update latest
  - For each of latest and tags, add new version information
 
+
+.. _getting_started-develpoment-version-files:
+
+Version Files
+=============
+
+The way that we define default versions for each of lmod and tcl is complicated enough that it is worth
+generating a table to show you! If you see a way to improve upon our current implementation, please let us know.
+Note that for the below, "automatic" refers to the setting ``default_version_automatic``, saying you want
+shpc to automatically update any default version files, and "default_version"
+refers to the ``default_version`` version setting, saying you want shpc to create and update a default version file.
+
+.. list-table:: Version File Logic
+   :widths: 20 20 20 20
+   :header-rows: 1
+
+   * - default_version
+     - false
+     - true but not automatic
+     - true and automatic
+   * - Lmod
+     - No .version file
+     - empty .version file, or .version file with a dummy non-matching string
+     - non-empty .version file, with a version number that exists
+   * - TCL
+     - .version file with a dummy non-matching string
+     - No .version file
+     - non-empty .version file, with a version number that exists
+
+In the case of a "dummy non-matching string" you could set something like ``please_specify_a_version_number``.
 
 .. _getting_started-development:
 

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -178,8 +178,8 @@ variable replacement. A summary table of variables is included below, and then f
      - a timestamp to keep track of when you last saved
      - never
    * - default_version
-     - A boolean to indicate whether a default version will be arbitrarily chosen, when multiple versions are available, and none is explicitly requested
-     - true
+     - Should a default version will be used?
+     - sys_module
    * - singularity_module
      - if defined, add to module script to load this Singularity module first
      - null
@@ -358,6 +358,18 @@ you can add or remove entries via the config variable ``registry``
 
 # Note that "add" is used for lists of things (e.g., the registry config variable is a list)
 and "set" is used to set a key value pair.
+
+
+Default Version
+---------------
+
+The default version setting is there to support you telling shpc how you want module versions to be selected.
+There are four options:
+
+ - ``sys_module``: allow the module software to choose (true also supported for backwards compatibility)
+ - ``null`` do not set any kind of default version, it will be manually controlled by the installer (false also supported for backwards compatibility)
+ - ``last_installed``: always set default version to the last version installed
+ - ``first_installed``: only set default version for the first installed
 
 
 Module Names

--- a/shpc/main/modules/__init__.py
+++ b/shpc/main/modules/__init__.py
@@ -22,8 +22,6 @@ class ModuleBase(BaseClient):
     def __init__(self, **kwargs):        
 
         # Files for module software to generate depending on user setting     
-        self.default_version_file = None
-        self.no_default_version_file = None
         super(ModuleBase, self).__init__(**kwargs)
         self.here = os.path.dirname(inspect.getfile(self.__class__))
 
@@ -39,31 +37,6 @@ class ModuleBase(BaseClient):
         with open(template_file, "r") as temp:
             template = Template(self.substitute(temp.read()))
         return template
-
-    def write_version_file(self, uri, tag):
-        """
-        Create the .version file, if there is a template for it.
-        """
-        version_dir = os.path.join(self.settings.module_base, uri)
-        version_file = os.path.join(version_dir, ".version")
-
-        # This is the first install if we have one directory (just created)
-        first_install = True if len(os.listdir(version_dir)) == 1 else False
-
-        # Case 1: we want a default version and have a file
-        template = None
-        if self.settings.default_version and self.default_version_file:
-            template = self._load_template(self.default_version_file)
-        
-        #self.settings.default_version_automatic
-        # Case 2: we don't want default versions and have a module file
-        elif not self.settings.default_version and self.no_default_version_file:
-            template = self._load_template(self.no_default_version_file)
-
-        # Render the template on first install, or automatic update enabled
-        if template and first_install or (not first_install and self.settings.default_version_automatic is True):
-            out = template.render(version=tag.name)
-            utils.write_file(version_file, out)
 
     def substitute(self, template):
         """

--- a/shpc/main/modules/lmod.py
+++ b/shpc/main/modules/lmod.py
@@ -3,7 +3,8 @@ __copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 from shpc.main.modules import ModuleBase
-
+import shpc.utils as utils
+import os
 
 class Client(ModuleBase):
     def __init__(self, **kwargs):
@@ -13,5 +14,22 @@ class Client(ModuleBase):
         super(Client, self).__init__(**kwargs)
         self.module_extension = "lua"
 
-        # lmod needs this file when default version is set
-        self.default_version_file = "default_version.lua"
+    def write_version_file(self, uri, tag):
+        """
+        Create the .version file, if there is a template for it.
+        """
+        version_dir = os.path.join(self.settings.module_base, uri)
+        version_file = os.path.join(version_dir, ".version")
+
+        # Case 1: no default version
+        if not self.settings.default_version:
+            return
+
+        # Case 2: default version with automatic version updates
+        if self.settings.default_version and self.settings.default_version_automatic is True:
+            template = self._load_template("default_version")
+            utils.write_file(version_file, template.render(version=tag.name))
+
+        # Case 3: default version but not automatic updates, Write an empty file
+        elif self.settings.default_version and self.settings.default_version_automatic is False:            
+            utils.write_file(version_file, "")

--- a/shpc/main/modules/lmod.py
+++ b/shpc/main/modules/lmod.py
@@ -4,7 +4,6 @@ __license__ = "MPL 2.0"
 
 from shpc.main.modules import ModuleBase
 import shpc.utils as utils
-import os
 
 class Client(ModuleBase):
     def __init__(self, **kwargs):

--- a/shpc/main/modules/lmod.py
+++ b/shpc/main/modules/lmod.py
@@ -12,3 +12,6 @@ class Client(ModuleBase):
         """
         super(Client, self).__init__(**kwargs)
         self.module_extension = "lua"
+
+        # lmod needs this file when default version is set
+        self.default_version_file = "default_version.lua"

--- a/shpc/main/modules/lmod.py
+++ b/shpc/main/modules/lmod.py
@@ -14,22 +14,12 @@ class Client(ModuleBase):
         super(Client, self).__init__(**kwargs)
         self.module_extension = "lua"
 
-    def write_version_file(self, uri, tag):
+    def _sys_module_default_version(self, version_file, tag):
         """
-        Create the .version file, if there is a template for it.
+        default version (default version in sys_module or True).
+        We generate a file with a non-existent version number.
         """
-        version_dir = os.path.join(self.settings.module_base, uri)
-        version_file = os.path.join(version_dir, ".version")
+        template = self._load_template("default_version")
+        utils.write_file(version_file, template.render())
 
-        # Case 1: no default version
-        if not self.settings.default_version:
-            return
-
-        # Case 2: default version with automatic version updates
-        if self.settings.default_version and self.settings.default_version_automatic is True:
-            template = self._load_template("default_version")
-            utils.write_file(version_file, template.render(version=tag.name))
-
-        # Case 3: default version but not automatic updates, Write an empty file
-        elif self.settings.default_version and self.settings.default_version_automatic is False:            
-            utils.write_file(version_file, "")
+     # LMOD False or null, don't generate a .version file

--- a/shpc/main/modules/tcl.py
+++ b/shpc/main/modules/tcl.py
@@ -22,7 +22,7 @@ class Client(ModuleBase):
         version_dir = os.path.join(self.settings.module_base, uri)
         version_file = os.path.join(version_dir, ".version")
 
-        # Case 1: no default version - generate a dummy empty file
+        # Case 1: no default version - generate a file with a non-existent version number
         if not self.settings.default_version:
             template = self._load_template("default_version")
             utils.write_file(version_file, template.render())

--- a/shpc/main/modules/tcl.py
+++ b/shpc/main/modules/tcl.py
@@ -4,7 +4,6 @@ __license__ = "MPL 2.0"
 
 from shpc.main.modules import ModuleBase
 import shpc.utils as utils
-import os
 
 
 class Client(ModuleBase):

--- a/shpc/main/modules/tcl.py
+++ b/shpc/main/modules/tcl.py
@@ -12,3 +12,6 @@ class Client(ModuleBase):
         """
         super(Client, self).__init__(**kwargs)
         self.module_extension = "tcl"
+        
+        # tcl needs this file when no default version set
+        self.no_default_version_file = "default_version.tcl"

--- a/shpc/main/modules/tcl.py
+++ b/shpc/main/modules/tcl.py
@@ -3,6 +3,8 @@ __copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 from shpc.main.modules import ModuleBase
+import shpc.utils as utils
+import os
 
 
 class Client(ModuleBase):
@@ -12,6 +14,21 @@ class Client(ModuleBase):
         """
         super(Client, self).__init__(**kwargs)
         self.module_extension = "tcl"
+                
+    def write_version_file(self, uri, tag):
+        """
+        Create the .version file, if there is a template for it.
+        """
+        version_dir = os.path.join(self.settings.module_base, uri)
+        version_file = os.path.join(version_dir, ".version")
+
+        # Case 1: no default version - generate a dummy empty file
+        if not self.settings.default_version:
+            template = self._load_template("default_version")
+            utils.write_file(version_file, template.render())
         
-        # tcl needs this file when no default version set
-        self.no_default_version_file = "default_version.tcl"
+        # Case 2: default version but not automatic update (no version file, skip)
+        # Case 3: default version and automatic update
+        elif self.settings.default_version and self.settings.default_version_automatic is True:
+            template = self._load_template("default_version")
+            utils.write_file(version_file, template.render(version=tag.name))

--- a/shpc/main/modules/tcl.py
+++ b/shpc/main/modules/tcl.py
@@ -14,21 +14,13 @@ class Client(ModuleBase):
         """
         super(Client, self).__init__(**kwargs)
         self.module_extension = "tcl"
-                
-    def write_version_file(self, uri, tag):
-        """
-        Create the .version file, if there is a template for it.
-        """
-        version_dir = os.path.join(self.settings.module_base, uri)
-        version_file = os.path.join(version_dir, ".version")
 
-        # Case 1: no default version - generate a file with a non-existent version number
-        if not self.settings.default_version:
-            template = self._load_template("default_version")
-            utils.write_file(version_file, template.render())
-        
-        # Case 2: default version but not automatic update (no version file, skip)
-        # Case 3: default version and automatic update
-        elif self.settings.default_version and self.settings.default_version_automatic is True:
-            template = self._load_template("default_version")
-            utils.write_file(version_file, template.render(version=tag.name))
+    def _no_default_version(self, version_file, tag):
+        """
+        No default version (default version in False or None).
+        We generate a file with a non-existent version number.
+        """
+        template = self._load_template("default_version")
+        utils.write_file(version_file, template.render())
+
+     # TCL sys_module or True default version, don't generate a .version file

--- a/shpc/main/modules/templates/default_version
+++ b/shpc/main/modules/templates/default_version
@@ -1,0 +1,2 @@
+#%Module
+set ModulesVersion "{% if version %}{{ version }}{% else %}please_specify_a_version_number{% endif %}"

--- a/shpc/main/modules/templates/default_version.tcl
+++ b/shpc/main/modules/templates/default_version.tcl
@@ -1,0 +1,2 @@
+#%Module
+set ModulesVersion "{% if version %}{{ version }}{% else %}please_specify_a_version_number{% endif %}"

--- a/shpc/main/modules/templates/default_version.tcl
+++ b/shpc/main/modules/templates/default_version.tcl
@@ -1,2 +1,0 @@
-#%Module
-set ModulesVersion "{% if version %}{{ version }}{% else %}please_specify_a_version_number{% endif %}"

--- a/shpc/main/modules/templates/no_default_version.tcl
+++ b/shpc/main/modules/templates/no_default_version.tcl
@@ -1,2 +1,0 @@
-#%Module
-set ModulesVersion "please_specify_a_version_number"

--- a/shpc/main/schemas.py
+++ b/shpc/main/schemas.py
@@ -138,6 +138,7 @@ settingsProperties = {
     "config_editor": {"type": "string"},
     "environment_file": {"type": "string"},
     "default_version": {"type": "boolean"},
+    "default_version_automatic": {"type": "boolean"},
     "enable_tty": {"type": "boolean"},
     "wrapper_scripts": wrapper_scripts,
     "container_tech": {"type": "string", "enum": ["singularity", "podman", "docker"]},

--- a/shpc/main/schemas.py
+++ b/shpc/main/schemas.py
@@ -137,8 +137,15 @@ settingsProperties = {
     "module_name": {"type": "string"},
     "config_editor": {"type": "string"},
     "environment_file": {"type": "string"},
-    "default_version": {"type": "boolean"},
-    "default_version_automatic": {"type": "boolean"},
+    "default_version": {
+        "oneOf": [
+            {"type": ["null", "boolean"]},
+            {
+                "type": "string",
+                "enum": ["sys_module", "last_installed", "first_installed"],
+            },
+        ]
+    },
     "enable_tty": {"type": "boolean"},
     "wrapper_scripts": wrapper_scripts,
     "container_tech": {"type": "string", "enum": ["singularity", "podman", "docker"]},

--- a/shpc/settings.yml
+++ b/shpc/settings.yml
@@ -27,8 +27,12 @@ module_base: $root_dir/modules
 # This is where you might add a prefix to your module names, if desired.
 module_name: '{{ parsed_name.tool }}'
 
-# When multiple versions are available and none requested, allow module picking one iself
+# When multiple versions are available and none requested, allow module picking one itself
 default_version: true
+
+# For tcl, set the default version to be the last installed
+# Disable this to set and manage your own default version
+default_version_automatic: true
 
 # store containers separately from module files
 # It's recommended to do this for faster loading

--- a/shpc/settings.yml
+++ b/shpc/settings.yml
@@ -28,11 +28,11 @@ module_base: $root_dir/modules
 module_name: '{{ parsed_name.tool }}'
 
 # When multiple versions are available and none requested, allow module picking one itself
-default_version: true
-
-# For tcl, set the default version to be the last installed
-# Disable this to set and manage your own default version
-default_version_automatic: true
+# sys_module: allow the module software to decide
+# null: do nothing, versions will be specified manually
+# last_installed: use the last installed as the default
+# first_installed: use the first installed
+default_version: sys_module
 
 # store containers separately from module files
 # It's recommended to do this for faster loading

--- a/shpc/tests/test_client.py
+++ b/shpc/tests/test_client.py
@@ -121,8 +121,20 @@ def test_tcl_default_version(tmp_path, automatic, default_version):
     module_dir = os.path.join(client.settings.module_base, "python")
     version_file = os.path.join(module_dir, ".version")
 
-    # tcl should exist when default_version is False
+    # tcl dummy file should exist when default_version is False
     if not default_version:
+        assert os.path.exists(version_file)
+        content = shpc.utils.read_file(version_file)
+
+        # The first install should always have it
+        assert "please_specify_a_version_number" in content
+
+    # If default version specified, the file should exist
+    elif default_version and not automatic:
+        assert not os.path.exists(version_file)
+
+    # default version and automatic updates file
+    else:
         assert os.path.exists(version_file)
         content = shpc.utils.read_file(version_file)
 
@@ -136,10 +148,6 @@ def test_tcl_default_version(tmp_path, automatic, default_version):
             assert "3.9.5-alpine" in content
         else:
             assert "3.9.2-alpine" in content
-
-    # If default version specified, the file should not exist
-    else:
-        assert not os.path.exists(version_file)
 
 
 @pytest.mark.parametrize(
@@ -169,8 +177,11 @@ def test_lmod_default_version(tmp_path, automatic, default_version):
         assert os.path.exists(version_file)
         content = shpc.utils.read_file(version_file)
 
-        # Content is always empty
-        assert content == ""
+        # Version is specified with automatic, otherwise empty
+        if not automatic:
+            assert content == ""
+        else:
+            assert "3.9.2-alpine" in content
 
     # If default version is not specified, the file should not exist
     else:

--- a/shpc/utils/__init__.py
+++ b/shpc/utils/__init__.py
@@ -8,6 +8,7 @@ from .terminal import (
 )
 from .fileio import (
     copyfile,
+    creation_date,
     get_file_hash,
     get_tmpdir,
     get_tmpfile,

--- a/shpc/utils/fileio.py
+++ b/shpc/utils/fileio.py
@@ -5,13 +5,24 @@ __license__ = "MPL 2.0"
 import hashlib
 import errno
 import os
-import stat
 import re
 import shutil
+import stat
 import tempfile
 
 import json
 from shpc.logger import logger
+
+
+def creation_date(filename):
+    """
+    Get the creation date, and fallback to modified date.
+    """
+    stat = os.stat(filename)
+    try:
+        return stat.st_birthtime
+    except AttributeError:
+        return stat.st_mtime
 
 
 def mkdirp(dirnames):


### PR DESCRIPTION
@muffato here are some suggested changes. To walk through the logic:

1. the base module class sets both files for having a default version `self.default_version_file` and not `self.no_default_version_file` to none, and then the specific modules can set them appropriately. I added notes to each of lmod and tcl because you are correct it gets confusing with the opposite logic!
2. I added a setting to allow the user to say "please update default versions for me." This means that on any first install of a version, we always add a version. but after that, if the automatic updates are disabled, we don't touch it. We honor their request to want to manually manage the module versioning. However, we give them a reasonable default to start with (the version they first installed).
3. in the function to load the version file, I moved the version_dir internal because it's only used here. I also take advantage of `self._load_template` so we can render a version into the jinja template, if appropriate.
4. I added tests for all the different cases of module software and settings for each of default version and default version automatic updates.

Let me know if this makes sense to you!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>