### PR TITLE
adding custom template loader

### DIFF
--- a/shpc/main/loader.py
+++ b/shpc/main/loader.py
@@ -1,0 +1,68 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2021-2022, Vanessa Sochat"
+__license__ = "MPL 2.0"
+
+from jinja2.exceptions import TemplateNotFound
+from jinja2 import FileSystemLoader
+from jinja2.loaders import split_template_path
+from jinja2.utils import open_if_exists
+import posixpath
+import os
+
+
+class CustomLoader(FileSystemLoader):
+    """
+    A custom loader will support providing a custom string, but also
+    includes within that. We do that by subclassing a FileSystemLoader,
+    which allows you to create a Jinja2 environment to load from a path.
+    E.g.,:
+
+    Example
+    -------
+    from jinja2 import Environment
+
+    # Allow includes from this directory OR providing strings
+    template_dir = os.path.join(root, "templates")
+    env = Environment(loader=loader.CustomLoader(template_dir))
+
+    # Load from a string
+    with open(template_file, "r") as temp:
+        template = env.get_template(self.substitute(temp.read()))
+
+    # Load from a filepath
+    template = env.get_template("includes/snippet.html")
+    """
+
+    def get_source(self, environment, template):
+        """
+        get_source first assumes looking for a file. If we get to the bottom
+        and cannot find it, assume a template and return the loaded template.
+        """
+        pieces = split_template_path(template)
+        for searchpath in self.searchpath:
+            # Use posixpath even on Windows to avoid "drive:" or UNC
+            # segments breaking out of the search directory.
+            filename = posixpath.join(searchpath, *pieces)
+            f = open_if_exists(filename)
+            if f is None:
+                continue
+            try:
+                contents = f.read().decode(self.encoding)
+            finally:
+                f.close()
+
+            mtime = os.path.getmtime(filename)
+
+            def uptodate() -> bool:
+                try:
+                    return os.path.getmtime(filename) == mtime
+                except OSError:
+                    return False
+
+            # Use normpath to convert Windows altsep to sep.
+            return contents, os.path.normpath(filename), uptodate
+
+        # Not perfect, but a way to guess it's not a template!
+        if "{%" not in template and "{{" not in template:
+            raise TemplateNotFound(template)
+        return template, None, None

--- a/shpc/main/loader.py
+++ b/shpc/main/loader.py
@@ -3,8 +3,7 @@ __copyright__ = "Copyright 2021-2022, Vanessa Sochat"
 __license__ = "MPL 2.0"
 
 from jinja2.exceptions import TemplateNotFound
-from jinja2 import FileSystemLoader
-from jinja2.loaders import split_template_path
+from jinja2.loaders import split_template_path, FileSystemLoader
 from jinja2.utils import open_if_exists
 import posixpath
 import os

--- a/shpc/main/modules/base.py
+++ b/shpc/main/modules/base.py
@@ -7,8 +7,8 @@ from shpc.logger import logger
 import shpc.utils as utils
 import shpc.defaults as defaults
 import shpc.main.templates
+import shpc.main.loader as loader
 import shpc.main.container as container
-from jinja2 import Template
 
 from datetime import datetime
 import os
@@ -17,7 +17,13 @@ import subprocess
 import sys
 import inspect
 
+from jinja2 import Environment
+
 here = os.path.dirname(os.path.abspath(__file__))
+
+# Allow includes from this directory OR providing strings
+template_dir = os.path.join(here, "templates")
+env = Environment(loader=loader.CustomLoader(template_dir))
 
 
 class ModuleBase(BaseClient):
@@ -42,9 +48,8 @@ class ModuleBase(BaseClient):
         """
         template_file = self._get_template(template_name)
 
-        # Make all substitutions here
         with open(template_file, "r") as temp:
-            template = Template(self.substitute(temp.read()))
+            template = env.get_template(self.substitute(temp.read()))
         return template
 
     def substitute(self, template):

--- a/shpc/main/modules/templates/docker.lua
+++ b/shpc/main/modules/templates/docker.lua
@@ -34,14 +34,7 @@ For each of the above, you can export:
  - PODMAN_COMMAND_OPTS: to define custom options for the command
 ]]) 
 
-{% if not settings.default_version %}
-if (mode() == "load") then
-  if ( myModuleUsrName() ~= myModuleFullName() and myModuleUsrName() ~= string.gsub(myModuleFullName(),"/module$","") ) then
-    LmodError("You must specify module <name>/<version>.")
-  end
-end
-{% endif %}
-
+{% include "includes/default_version.lua" %}
 {% if settings.podman_module %}load("{{ settings.podman_module }}"){% endif %}
 
 -- Environment: only set options and command options if not already set

--- a/shpc/main/modules/templates/includes/default_version.lua
+++ b/shpc/main/modules/templates/includes/default_version.lua
@@ -1,0 +1,5 @@
+{% if not settings.default_version %}if (mode() == "load") then
+  if ( myModuleUsrName() ~= myModuleFullName() and myModuleUsrName() ~= string.gsub(myModuleFullName(),"/module$","") ) then
+    LmodError("You must specify module <name>/<version>.")
+  end
+end{% endif %}

--- a/shpc/main/modules/templates/singularity.lua
+++ b/shpc/main/modules/templates/singularity.lua
@@ -36,14 +36,7 @@ For each of the above, you can export:
  - SINGULARITY_COMMAND_OPTS: to define custom options for the command (e.g., -b)
 ]]) 
 
-{% if not settings.default_version %}
-if (mode() == "load") then
-  if ( myModuleUsrName() ~= myModuleFullName() and myModuleUsrName() ~= string.gsub(myModuleFullName(),"/module$","") ) then
-    LmodError("You must specify module <name>/<version>.")
-  end
-end
-{% endif %}
-
+{% include "includes/default_version.lua" %}
 {% if settings.singularity_module %}load("{{ settings.singularity_module }}"){% endif %}
 
 -- directory containing this modulefile, once symlinks resolved (dynamically defined)

--- a/shpc/main/settings.py
+++ b/shpc/main/settings.py
@@ -21,7 +21,7 @@ import jsonschema
 import os
 import re
 
-# Legacy values we still support for backwards compatibility,
+# Legacy values we still support for backwards compatibility,
 # and a mapping to the new value that should be used.
 legacy_values = {
     "default_version": {
@@ -29,6 +29,7 @@ legacy_values = {
         True: "module_sys",
     },
 }
+
 
 def OrderedList(*l):
     ret = CommentedSeq(l)


### PR DESCRIPTION
This loader allows loading from a filepath (first preference if it exists) and then checks the string for template syntax and returns that directly if found, otherwise we default to the TemplateNotFound error being raised. This is helpful if we want to ultimately load a custom string but still allow for includes blocks in that string

Update: I have no idea if this is a *good idea* but I do think it would be nice to support loading from string without having the duplication! If we are sure that the module loader doesn't ever load anything outside of that directory, we can just default to using it. But working on wrappers, at least, I do remember it can be loaded from a container directory or the wrappers directory, so it might be something we would eventually want. 

Update: it looks like we still use the FileSystemLoader for the custom wrappers - I just derive the path on the fly! So perhaps I should just adjust the PR here to do that, but automatically for the modules directory:
https://github.com/singularityhub/singularity-hpc/blob/610234275ab39badeddb6f6e4ba42b68988baaaa/shpc/main/wrappers/base.py#L103-L105

Thoughts @muffato ?

Signed-off-by: vsoch <vsoch@users.noreply.github.com>