### PR TITLE
addition of intermediate module class

### DIFF
--- a/shpc/client/view.py
+++ b/shpc/client/view.py
@@ -52,6 +52,8 @@ def create_from_file(
 
     # Extra modules to install
     for install_module in install_modules:
+
+        # TODO: can we cut out early if already installed?
         cli.install(install_module, force=force)
         cli.view_install(view_name, install_module, force=force)
 

--- a/shpc/main/__init__.py
+++ b/shpc/main/__init__.py
@@ -41,17 +41,17 @@ def get_client(quiet=False, **kwargs):
 
     # Add the container operator
     if container == "singularity":
-        from .container import SingularityContainer
+        from shpc.main.container import SingularityContainer
 
         Client.container = SingularityContainer()
 
     elif container == "podman":
-        from .container import PodmanContainer
+        from shpc.main.container import PodmanContainer
 
         Client.container = PodmanContainer()
 
     elif container == "docker":
-        from .container import DockerContainer
+        from shpc.main.container import DockerContainer
 
         Client.container = DockerContainer()
 
@@ -64,6 +64,8 @@ def get_client(quiet=False, **kwargs):
         logger.warning(
             "%s is not installed, functionality might be limited." % container.upper()
         )
+
+    # Pass on settings and container to module too
     Client.quiet = quiet
     Client.settings = settings
     return Client()

--- a/shpc/main/container/docker.py
+++ b/shpc/main/container/docker.py
@@ -234,6 +234,7 @@ class DockerContainer(ContainerTechnology):
             creation_date=datetime.now(),
             command=self.command,
             module=module,
+            parsed_name=module.config.name,
             wrapper_scripts=wrapper_scripts,
         )
         shpc.utils.write_file(module_path, out)

--- a/shpc/main/container/docker.py
+++ b/shpc/main/container/docker.py
@@ -185,21 +185,7 @@ class DockerContainer(ContainerTechnology):
         # Return code
         return result["return_code"]
 
-    def install(
-        self,
-        module_path,
-        container_path,
-        name,
-        template,
-        parsed_name,
-        aliases=None,
-        url=None,
-        description=None,
-        version=None,
-        config_features=None,
-        features=None,
-        config=None,
-    ):
+    def install(self, module_path, template, module, features=None):
         """Install a general container path to a module
 
         The module_dir should be created by the calling function, and
@@ -210,50 +196,44 @@ class DockerContainer(ContainerTechnology):
         # Container features are defined in container.yaml and the settings
         # and specific values are determined by the container technology
         features = self.get_features(
-            config_features, self.settings.container_features, features
+            module.config.features, self.settings.container_features, features
         )
 
         # Ensure that the container exists
         # Do we want to clean up other versions here too?
-        manifest = self.inspect(container_path)
+        manifest = self.inspect(module.container_path)
         if not manifest:
-            sys.exit("Container %s was not found. Was it pulled?" % container_path)
+            sys.exit(
+                "Container %s was not found. Was it pulled?" % module.container_path
+            )
 
         labels = manifest[0].get("Labels", {})
 
-        # If there's a tag in the name, don't use it
-        name = name.split(":", 1)[0]
-
         # Option to create wrapper scripts for commands
-        module_dir = os.path.dirname(module_path)
+        aliases = module.config.get_aliases()
         wrapper_scripts = []
 
         # Wrapper scripts can be global (for aliases) or container specific
         if self.settings.wrapper_scripts["enabled"] is True:
             wrapper_scripts = shpc.main.wrappers.generate(
                 aliases=aliases,
-                module_dir=module_dir,
+                module_dir=module.module_dir,
                 features=features,
                 container=self,
-                image=container_path,
-                config=config,
+                image=module.container_path,
+                config=module.config,
             )
 
         # Make sure to render all values!
         out = template.render(
             settings=self.settings,
             shell=self.shell_path,
-            image=container_path,
-            description=description,
             aliases=aliases,
-            url=url,
             features=features,
-            version=version,
             labels=labels,
             creation_date=datetime.now(),
-            name=name,
-            parsed_name=parsed_name,
             command=self.command,
+            module=module,
             wrapper_scripts=wrapper_scripts,
         )
         shpc.utils.write_file(module_path, out)

--- a/shpc/main/container/singularity.py
+++ b/shpc/main/container/singularity.py
@@ -224,6 +224,7 @@ class SingularityContainer(ContainerTechnology):
             deffile=deffile,
             creation_date=datetime.now(),
             module=module,
+            parsed_name=module.config.name,
             wrapper_scripts=wrapper_scripts,
         )
         utils.write_file(module_path, out)

--- a/shpc/main/modules/module.py
+++ b/shpc/main/modules/module.py
@@ -1,0 +1,142 @@
+__author__ = "Vanessa Sochat"
+__copyright__ = "Copyright 2022, Vanessa Sochat"
+__license__ = "MPL 2.0"
+
+import os
+import shutil
+from shpc.logger import logger
+
+
+class Module:
+    def __init__(self, name):
+        """
+        New module metadata and shared functions.
+
+        This should be created by base.py new_module to ensure the same
+        container and settings are carried forward here.
+        """
+        self.name = name
+
+        # Cache variable properties
+        self._uri = None
+        self._container_dir = None
+        self._container_path = None
+
+    @property
+    def tagged_name(self):
+        name = self.name
+        if ":" not in name:
+            name = "%s:%s" % (name, self.tag.name)
+        return name
+
+    def add_environment(self):
+        """
+        Write the environment to the module directory.
+        """
+        self.container.add_environment(
+            self.module_dir,
+            envars=self.config.get_envars(),
+            environment_file=self.settings.environment_file,
+        )
+
+    def validate_tag_exists(self):
+        """
+        Ensure that a provided module name (and tag) exists.
+        """
+        if not self.config.tag:
+            logger.exit(
+                "%s is not a known identifier. Choices are:\n%s"
+                % (self.name, "\n".join(self.config.tags.keys()))
+            )
+
+    def load_override_file(self):
+        self.config.load_override_file(self.tag.name)
+
+    @property
+    def container_dir(self):
+        """
+        Derive the module container directory.
+        """
+        if not self._container_dir:
+            # Pull the container to the module directory OR container base
+            self._container_dir = self.container.container_dir(self.module_basepath)
+        return self._container_dir
+
+    @property
+    def container_path(self):
+        """
+        Derive the container path, if possible.
+        """
+        if self._container_path:
+            return self._container_path
+
+        # If we have a sif URI provided by path, the container needs to exist
+        if self.config.path:
+            self._container_path = os.path.join(
+                self.config.entry.dirname, self.config.path
+            )
+            if not os.path.exists(self._container_path):
+                logger.exit(
+                    "Expected container defined by path %s not found in %s."
+                    % (self.config.path, self.config.entry.dirname)
+                )
+            container_dest = os.path.join(self.container_dir, self.config.path)
+
+            # Note that here we are *duplicating* the container, assuming we
+            # cannot use a link, and the registry won't be deleted but the
+            # module container might!
+            if not os.path.exists(container_dest):
+                shutil.copyfile(self._container_path, container_dest)
+            self._container_path = container_dest
+
+        # For Singularity this is a path, podman is a uri. If None is returned
+        # there was an error and we cleanup
+        if not self._container_path:
+            self._container_path = self.container.registry_pull(
+                self.module_dir, self.container_dir, self.config, self.tag
+            )
+        return self._container_path
+
+    @property
+    def tag(self):
+        """
+        Pass forward the tag defined in the config.
+        """
+        return self.config.tag
+
+    def check(self):
+        """
+        Check to see if the module version installed is up to date.
+        """
+        return self.container.check(self.name, self.config)
+
+    @property
+    def uri(self):
+        """
+        Get the uri for the module, docker / path / oras / gh
+        """
+        if self._uri:
+            return self._uri
+
+        # We currently support gh, docker, path, or oras
+        uri = self.config.get_uri()
+
+        # If we have a path, the URI comes from the name
+        if ".sif" in uri:
+            uri = self.name.split(":", 1)[0]
+        self._uri = uri
+        return uri
+
+    @property
+    def module_dir(self):
+        """
+        Full path to the module directory.
+        """
+        return os.path.join(self.settings.module_base, self.module_basepath)
+
+    @property
+    def module_basepath(self):
+        """
+        Path of only the module name and tag.
+        """
+        return os.path.join(self.uri, self.tag.name)

--- a/shpc/main/modules/template.py
+++ b/shpc/main/modules/template.py
@@ -46,7 +46,7 @@ class Template:
         For all known identifiers, substitute user specified format strings.
         """
         subs = {
-            "{|module_name|}": self.settings.module_name or "{{ parsed_name.tool }}"
+            "{|module_name|}": self.settings.module_name or "{{ config.name.tool }}"
         }
         for key, replacewith in subs.items():
             template = template.replace(key, replacewith)

--- a/shpc/main/modules/templates/docker.lua
+++ b/shpc/main/modules/templates/docker.lua
@@ -1,17 +1,17 @@
 -- Lmod Module
 -- Created by singularity-hpc (https://github.com/singularityhub/singularity-hpc)
 -- ##
--- {{ name }} on {{ creation_date }}
+-- {{ module.name }} on {{ creation_date }}
 --
 
 help(
 [[
-This module is a {{ command }} container wrapper for {{ name }} v{{ version }}
-{% if description %}{{ description }}{% endif %}
+This module is a {{ command }} container wrapper for {{ module.name }} v{{ module.tag.name }}
+{% if description %}{{ module.config.description }}{% endif %}
 
 Container:
 
- - {{ image }}
+ - {{ module.container_path }}
 
 Commands include:
 
@@ -49,7 +49,7 @@ if not os.getenv("PODMAN_COMMAND_OPTS") then setenv ("PODMAN_COMMAND_OPTS", "") 
 local moduleDir = subprocess("realpath " .. myFileName()):match("(.*[/])") or "."
 
 -- interactive shell to any container, plus exec for aliases
-local containerPath = '{{ image }}'
+local containerPath = '{{ module.container_path }}'
 
 -- service environment variable to access docker URI
 setenv("PODMAN_CONTAINER", containerPath)
@@ -61,7 +61,7 @@ local runCmd = "{{ command }} ${PODMAN_OPTS} run ${PODMAN_COMMAND_OPTS} -i{% if 
 local inspectCmd = "{{ command }} ${PODMAN_OPTS} inspect ${PODMAN_COMMAND_OPTS} " .. containerPath 
 
 -- conflict with modules with the same name
-conflict("{{ parsed_name.tool }}"{% if name != parsed_name.tool %},"{{ name }}"{% endif %}{% if aliases %}{% for alias in aliases %}{% if alias.name != parsed_name.tool %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
+conflict("{{ parsed_name.tool }}"{% if name != parsed_name.tool %},"{{ module.name }}"{% endif %}{% if aliases %}{% for alias in aliases %}{% if alias.name != parsed_name.tool %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
 
 -- if we have any wrapper scripts, add the bin directory
 {% if wrapper_scripts %}prepend_path("PATH", pathJoin(moduleDir, "bin")){% endif %}
@@ -92,7 +92,7 @@ set_shell_function("{|module_name|}-inspect", inspectCmd,  inspectCmd){% endif %
 
 whatis("Name        : " .. myModuleName())
 whatis("Version     : " .. myModuleVersion())
-{% if description %}whatis("Description    : {{ description }}"){% endif %}
-{% if url %}whatis("Url         : {{ url }}"){% endif %}
+{% if description %}whatis("Description    : {{ module.config.description }}"){% endif %}
+{% if url %}whatis("Url         : {{ module.config.url }}"){% endif %}
 {% if labels %}{% for key, value in labels.items() %}whatis("{{ key }}    : {{ value }}")
 {% endfor %}{% endif %}

--- a/shpc/main/modules/templates/docker.tcl
+++ b/shpc/main/modules/templates/docker.tcl
@@ -3,16 +3,16 @@
 #=====
 # Created by singularity-hpc (https://github.com/singularityhub/singularity-hpc)
 # ##
-# {{ name }} on {{ creation_date }}
+# {{ module.name }} on {{ creation_date }}
 #=====
 
 proc ModulesHelp { } {
 
-    puts stderr "This module is a {{ command }} container wrapper for {{ name }} v{{ version }}"
-    {% if description %}puts stderr "{{ description }}"{% endif %}
+    puts stderr "This module is a {{ command }} container wrapper for {{ module.name }} v{{ module.tag.name }}"
+    {% if description %}puts stderr "{{ module.config.description }}"{% endif %}
     puts stderr ""
     puts stderr "Container:"
-    puts stderr " - {{ image }}"
+    puts stderr " - {{ module.container_path }}"
     puts stderr "Commands include:"
     puts stderr " - {|module_name|}-run:"
     puts stderr "       {{ command }} run -i{% if settings.enable_tty %}t{% endif %} -u `id -u`:`id -g` --rm {% if settings.environment_file %}--env-file  <moduleDir>/{{ settings.environment_file }} {% endif %} {% if settings.bindpaths %}-v {{ settings.bindpaths }} {% endif %}{% if features.home %}-v {{ features.home }} {% endif %} -v . -w . <container> \"\$@\""
@@ -48,14 +48,14 @@ if { ![info exists ::env(PODMAN_COMMAND_OPTS)] } {
 
 # Variables
 
-set name        "{{ name }}"
-set version     "{{ version }}"
+set name        "{{ module.name }}"
+set version     "{{ module.tag.name }}"
 set description "$name - $version"
-set containerPath "{{ image }}"
+set containerPath "{{ module.container_path }}"
 set workdir [pwd]
-{% if description %}set notes       "{{ description }}"{% endif %}
-{% if url %}set homepage    "{{ url }}"{% endif %}
-set helpcommand "This module is a {{ docker }} container wrapper for {{ name }} v{{ version }}. {% if description %}{{ description }}{% endif %}"
+{% if description %}set notes       "{{ module.config.description }}"{% endif %}
+{% if url %}set homepage    "{{ module.config.url }}"{% endif %}
+set helpcommand "This module is a {{ docker }} container wrapper for {{ module.name }} v{{ module.tag.name }}. {% if description %}{{ module.config.description }}{% endif %}"
 {% if labels %}{% for key, value in labels.items() %}set {{ key }} "{{ value }}"
 {% endfor %}{% endif %}
 
@@ -64,7 +64,7 @@ set moduleDir   [file dirname [expr { [string equal [file type ${ModulesCurrentM
 
 # conflict with modules with the same alias name
 conflict {{ parsed_name.tool }}
-{% if name != parsed_name.tool %}conflict {{ name }}{% endif %}
+{% if name != parsed_name.tool %}conflict {{ module.name }}{% endif %}
 {% if aliases %}{% for alias in aliases %}{% if alias.name != parsed_name.tool %}conflict {{ alias.name }}{% endif %}
 {% endfor %}{% endif %}
 
@@ -122,10 +122,10 @@ set-alias {|module_name|}-inspect "${inspectCmd} ${containerPath}"{% endif %}
 #=====
 # Module options
 #=====
-module-whatis "    Name: {{ name }}"
-module-whatis "    Version: {{ version }}"
+module-whatis "    Name: {{ module.name }}"
+module-whatis "    Version: {{ module.tag.name }}"
 {% if description %}module-whatis "    Description: ${description}"{% endif %}
-{% if url %}module-whatis "    Url: {{ url }}"{% endif %}
+{% if url %}module-whatis "    Url: {{ module.config.url }}"{% endif %}
 {% if labels %}{% for key, value in labels.items() %}module-whatis "    {{ key }}: {{ value }}"
 {% endfor %}{% endif %}
 {% if settings.podman_module %}module load {{ settings.podman_module }}{% endif %}

--- a/shpc/main/modules/templates/singularity.lua
+++ b/shpc/main/modules/templates/singularity.lua
@@ -1,17 +1,17 @@
 -- Lmod Module
 -- Created by singularity-hpc (https://github.com/singularityhub/singularity-hpc)
 -- ##
--- {{ name }} on {{ creation_date }}
+-- {{ module.name }} on {{ creation_date }}
 --
 
 help(
 [[
-This module is a singularity container wrapper for {{ name }} v{{ version }}
-{% if description %}{{ description }}{% endif %}
+This module is a singularity container wrapper for {{ module.name }} v{{ module.tag.name }}
+{% if description %}{{ module.config.description }}{% endif %}
 
 Container (available through variable SINGULARITY_CONTAINER):
 
- - {{ container_sif }}
+ - {{ module.container_path }}
 
 Commands include:
 
@@ -53,7 +53,7 @@ setenv("SINGULARITY_SHELL", "{{ settings.singularity_shell }}")
 if not os.getenv("SINGULARITY_OPTS") then setenv ("SINGULARITY_OPTS", "") end
 if not os.getenv("SINGULARITY_COMMAND_OPTS") then setenv ("SINGULARITY_COMMAND_OPTS", "") end
 
-local containerPath = '{{ container_sif }}'
+local containerPath = '{{ module.container_path }}'
 -- service environment variable to access full SIF image path
 setenv("SINGULARITY_CONTAINER", containerPath)
 
@@ -64,7 +64,7 @@ local runCmd = "singularity ${SINGULARITY_OPTS} run ${SINGULARITY_COMMAND_OPTS} 
 local inspectCmd = "singularity ${SINGULARITY_OPTS} inspect ${SINGULARITY_COMMAND_OPTS} " 
 
 -- conflict with modules with the same name
-conflict("{{ parsed_name.tool }}"{% if name != parsed_name.tool %},"{{ name }}"{% endif %}{% if aliases %}{% for alias in aliases %}{% if alias.name != parsed_name.tool %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
+conflict("{{ parsed_name.tool }}"{% if name != parsed_name.tool %},"{{ module.name }}"{% endif %}{% if aliases %}{% for alias in aliases %}{% if alias.name != parsed_name.tool %},"{{ alias.name }}"{% endif %}{% endfor %}{% endif %})
 
 -- if we have any wrapper scripts, add bin to path
 {% if wrapper_scripts %}prepend_path("PATH", pathJoin(moduleDir, "bin")){% endif %}
@@ -98,7 +98,7 @@ set_shell_function("{|module_name|}-inspect-deffile", inspectCmd .. " -d  " .. c
 
 whatis("Name        : " .. myModuleName())
 whatis("Version     : " .. myModuleVersion())
-{% if description %}whatis("Description    : {{ description }}"){% endif %}
-{% if url %}whatis("Url         : {{ url }}"){% endif %}
+{% if description %}whatis("Description    : {{ module.config.description }}"){% endif %}
+{% if url %}whatis("Url         : {{ module.config.url }}"){% endif %}
 {% if labels %}{% for key, value in labels.items() %}whatis("{{ key }}    : {{ value }}")
 {% endfor %}{% endif %}

--- a/shpc/main/modules/templates/singularity.tcl
+++ b/shpc/main/modules/templates/singularity.tcl
@@ -3,17 +3,17 @@
 #=====
 # Created by singularity-hpc (https://github.com/singularityhub/singularity-hpc)
 # ##
-# {{ name }} on {{ creation_date }}
+# {{ module.name }} on {{ creation_date }}
 #=====
 
 proc ModulesHelp { } {
 
-    puts stderr "This module is a singularity container wrapper for {{ name }} v{{ version }}"
-    {% if description %}puts stderr "{{ description }}"{% endif %}
+    puts stderr "This module is a singularity container wrapper for {{ module.name }} v{{ module.tag.name }}"
+    {% if description %}puts stderr "{{ module.config.description }}"{% endif %}
     puts stderr ""
     puts stderr "Container (available through variable SINGULARITY_CONTAINER):"
     puts stderr ""
-    puts stderr " - {{ container_sif }}"
+    puts stderr " - {{ module.container_path }}"
     puts stderr ""
     puts stderr "Commands include:"
     puts stderr ""
@@ -54,13 +54,13 @@ if { ![info exists ::env(SINGULARITY_COMMAND_OPTS)] } {
 
 # Variables
 
-set name        {{ name }}
-set version     {{ version }}
+set name        {{ module.name }}
+set version     {{ module.tag.name }}
 set description "$name - $version"
-set containerPath {{ container_sif }}
-{% if description %}set notes       "{{ description }}"{% endif %}
-{% if url %}set homepage    "{{ url }}"{% endif %}
-set helpcommand "This module is a singularity container wrapper for {{ name }} v{{ version }}. {% if description %}{{ description }}{% endif %}"
+set containerPath {{ module.container_path }}
+{% if description %}set notes       "{{ module.config.description }}"{% endif %}
+{% if url %}set homepage    "{{ module.config.url }}"{% endif %}
+set helpcommand "This module is a singularity container wrapper for {{ module.name }} v{{ module.tag.name }}. {% if description %}{{ module.config.description }}{% endif %}"
 {% if labels %}{% for key, value in labels.items() %}set {{ key }} "{{ value }}"
 {% endfor %}{% endif %}
 
@@ -69,7 +69,7 @@ set moduleDir   [file dirname [expr { [string equal [file type ${ModulesCurrentM
 
 # conflict with modules with the same alias name
 conflict {{ parsed_name.tool }}
-{% if name != parsed_name.tool %}conflict {{ name }}{% endif %}
+{% if name != parsed_name.tool %}conflict {{ module.name }}{% endif %}
 {% if aliases %}{% for alias in aliases %}{% if alias.name != parsed_name.tool %}conflict {{ alias.name }}{% endif %}
 {% endfor %}{% endif %}
 
@@ -128,10 +128,10 @@ set-alias {|module_name|}-inspect-deffile "${inspectCmd} -d ${containerPath}"{% 
 #=====
 # Module options
 #=====
-module-whatis "    Name: {{ name }}"
-module-whatis "    Version: {{ version }}"
+module-whatis "    Name: {{ module.name }}"
+module-whatis "    Version: {{ module.tag.name }}"
 {% if description %}module-whatis "    Description: ${description}"{% endif %}
-{% if url %}module-whatis "    Url: {{ url }}"{% endif %}
+{% if url %}module-whatis "    Url: {{ module.config.url }}"{% endif %}
 {% if labels %}{% for key, value in labels.items() %}module-whatis "    {{ key }}: {{ value }}"
 {% endfor %}{% endif %}
 {% if settings.singularity_module %}module load {{ settings.singularity_module }}{% endif %}


### PR DESCRIPTION
Here is the suggestion I started last night (and woke up really early and felt like working on - although going back to bed again soon!) I thought it would be a good opportunity to have an intermediate class to help to carry around some common data attributes and functions, and reduce redundancy within the ModuleBase class. It also allows for providing fewer variables to the rendered templates since they can come from the module. Specifically:

 - within install / uninstall /check we use self.new_module(...) to get a new module object. The reason I did it like this is to carry around the container and settings, and we can add/remove functionality from here as desired (the idea was to try and put shared or common functionality in one place).
 - within the templates we can also now reference the module, which has the config and other module attributes (which we used to pass separately) and you'll notice the arguments to install() are much fewer! The only one I kept the same is parsed_name since that is exposed to the user in settings.yaml and asking them to define module.config.name.tool (or similar) would be weird (or a step more complex than what we have now).

Apologies in advance for mistakes I probably shouldn't be programming in the middle of the night... but wanted to get this idea to you asap! I do think shpc is a big class-heavy compared to some of my other projects, but I'm really enjoying playing around with these designs (and generally think we are slowly making it better!). Okay back to bed, g'nite!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>